### PR TITLE
Update the naming convention for Torch and switch to zip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build
 install
 *.tgz
+*.zip
+*.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -81,8 +81,9 @@ build_torch: $(TORCH_BUILD) $(TORCH_INSTALL) checkout_torch
 		make install -j 4
 
 $(TORCH_TARGET): build_torch
-	cd install && tar -czf ../$@ libtorch
+	cd install && zip -r ../$@ libtorch
 
 .PHONY: clean_torch
 clean_torch:
- 	rm -rf $(TORCH_BUILD) $(TORCH_TARGET) $(TORCH_INSTALL)
+	rm -rf $(TORCH_BUILD) $(TORCH_TARGET) $(TORCH_INSTALL)
+


### PR DESCRIPTION
The official libtorch releases are bundled as zip files and not gzipped tarballs. Additionally, in the naming convention no 'v' is pre-prepended to the version number. This PR attempts to follow these conventions more closely, notably deviating by adding `arm64` to the archive name to distinguish the architecture.